### PR TITLE
Reduce the number of MSBuild instances that run in parallel

### DIFF
--- a/windows/rebuild/action.yaml
+++ b/windows/rebuild/action.yaml
@@ -15,7 +15,7 @@ runs:
         {
         &"${{ env.PRINCIPIA_MSBUILD_PATH }}"
         /target:"Clean;Build"
-        /maxCpuCount
+        /maxCpuCount:((Get-CimInstance Win32_ComputerSystem).NumberOfLogicalProcessors / 2)
         /property:Configuration=${{ inputs.configuration }}
         /property:Platform=x64
         $_

--- a/windows/rebuild/action.yaml
+++ b/windows/rebuild/action.yaml
@@ -11,7 +11,7 @@ runs:
   using: 'composite'
   steps:
     - run: |
-        $max_cpu_count = (Get-CimInstance Win32_ComputerSystem).NumberOfLogicalProcessors / 2
+        $max_cpu_count = (Get-CimInstance Win32_ComputerSystem).NumberOfLogicalProcessors / 4
         ls ${{ inputs.solution_directory }}\*.sln | %       `
         {                                                   `
         &"${{ env.PRINCIPIA_MSBUILD_PATH }}"                `

--- a/windows/rebuild/action.yaml
+++ b/windows/rebuild/action.yaml
@@ -10,17 +10,17 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - run: >
+    - run: |
         $max_cpu_count = (Get-CimInstance Win32_ComputerSystem).NumberOfLogicalProcessors / 2
-        ls ${{ inputs.solution_directory }}\*.sln | %
-        {
-        &"${{ env.PRINCIPIA_MSBUILD_PATH }}"
-        /target:"Clean;Build"
-        /maxCpuCount:$max_cpu_count
-        /property:Configuration=${{ inputs.configuration }}
-        /property:Platform=x64
-        $_
-        }
+        ls ${{ inputs.solution_directory }}\*.sln | %       `
+        {                                                   `
+        &"${{ env.PRINCIPIA_MSBUILD_PATH }}"                `
+        /target:"Clean;Build"                               `
+        /maxCpuCount:$max_cpu_count                         `
+        /property:Configuration=${{ inputs.configuration }} `
+        /property:Platform=x64                              `
+        $_                                                  `
+        }                                                   `
       shell: pwsh
       env:
         PRINCIPIA_MSBUILD_PATH: C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\MSBuild.exe

--- a/windows/rebuild/action.yaml
+++ b/windows/rebuild/action.yaml
@@ -11,11 +11,12 @@ runs:
   using: 'composite'
   steps:
     - run: >
+        $max_cpu_count = (Get-CimInstance Win32_ComputerSystem).NumberOfLogicalProcessors / 2
         ls ${{ inputs.solution_directory }}\*.sln | %
         {
         &"${{ env.PRINCIPIA_MSBUILD_PATH }}"
         /target:"Clean;Build"
-        /maxCpuCount:((Get-CimInstance Win32_ComputerSystem).NumberOfLogicalProcessors / 2)
+        /maxCpuCount:$max_cpu_count
         /property:Configuration=${{ inputs.configuration }}
         /property:Platform=x64
         $_

--- a/windows/test/action.yaml
+++ b/windows/test/action.yaml
@@ -8,7 +8,7 @@ runs:
   using: 'composite'
   steps:
     - run: |
-        New-Item -ItemType Directory -Force TestResults
+        $null = New-Item -ItemType Directory -Force TestResults
         Remove-Item -Recurse -ErrorAction SilentlyContinue TestResults/*
         if ( "${{ inputs.configuration }}" -eq 'Debug') {
           $granularity = 'Package'


### PR DESCRIPTION
It still uses 100% of the CPU during build, and I am hoping that it will improve the health of the VM.